### PR TITLE
Allow to customize a message of action log

### DIFF
--- a/lib/rails_semantic_logger/engine.rb
+++ b/lib/rails_semantic_logger/engine.rb
@@ -226,6 +226,7 @@ module RailsSemanticLogger
         if defined?(::ActionController)
           require "action_controller/log_subscriber"
 
+          RailsSemanticLogger::ActionController::LogSubscriber.action_message_format = config.rails_semantic_logger.action_message_format
           RailsSemanticLogger.swap_subscriber(
             ::ActionController::LogSubscriber,
             RailsSemanticLogger::ActionController::LogSubscriber,

--- a/lib/rails_semantic_logger/options.rb
+++ b/lib/rails_semantic_logger/options.rb
@@ -100,23 +100,32 @@ module RailsSemanticLogger
   # * named_tags: *DEPRECATED*
   #   Instead, supply a Hash to config.log_tags
   #   config.rails_semantic_logger.named_tags = nil
+  #
+  # * Change the message format of Action Controller action.
+  #   A block that will be called to format the message.
+  #   It is supplied with the `message` and `payload` and should return the formatted data.
+  #
+  #     config.rails_semantic_logger.action_message_format = -> (message, payload) do
+  #       "#{message} - #{payload[:controller]}##{payload[:action]}"
+  #     end
   class Options
     attr_accessor :semantic, :started, :processing, :rendered, :ap_options, :add_file_appender,
-                  :quiet_assets, :format, :named_tags, :filter, :console_logger
+                  :quiet_assets, :format, :named_tags, :filter, :console_logger, :action_message_format
 
     # Setup default values
     def initialize
-      @semantic          = true
-      @started           = false
-      @processing        = false
-      @rendered          = false
-      @ap_options        = {multiline: false}
-      @add_file_appender = true
-      @quiet_assets      = false
-      @format            = :default
-      @named_tags        = nil
-      @filter            = nil
-      @console_logger    = true
+      @semantic              = true
+      @started               = false
+      @processing            = false
+      @rendered              = false
+      @ap_options            = {multiline: false}
+      @add_file_appender     = true
+      @quiet_assets          = false
+      @format                = :default
+      @named_tags            = nil
+      @filter                = nil
+      @console_logger        = true
+      @action_message_format = nil
     end
   end
 end


### PR DESCRIPTION
Currently, a message of action log is a fixed value. Some services(e.g. Datadog) emphasize a `message` value. So sometimes we want to add more information to that column.

This PR adds the config to customize that value. We can change the value like the following.

```ruby
config.rails_semantic_logger.action_message_format = -> (message, payload) do
  "#{message} - #{payload[:controller]}##{payload[:action]}"
end
```

### Issue # (if available)


### Description of changes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
